### PR TITLE
Add LFP functor from separate repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ common_package(BBPTestData)
 common_package(Boost REQUIRED COMPONENTS unit_test_framework
                                          program_options system)
 common_package(Brion REQUIRED)
-common_package(ITK REQUIRED)
+common_package(ITK REQUIRED SYSTEM)
 common_package(Livre)
 common_package(Monsteer REQUIRED)
 common_package(vmmlib REQUIRED)
@@ -43,6 +43,16 @@ include(${ITK_USE_FILE})
 # the link line. Removing the tokens fixes the build, although I have
 # not fully understood the issue.
 list(REMOVE_ITEM ITK_LIBRARIES optimized debug)
+
+# Try cloning lfpFivox into the 'fivox' folder
+set(FIVOXLFP_DIR ${PROJECT_SOURCE_DIR}/fivox/lfp)
+git_external(${FIVOXLFP_DIR} ssh://bbpcode.epfl.ch/viz/lfpFivox master OPTIONAL)
+
+# Add LFP-related headers and definitions if found
+if(EXISTS ${FIVOXLFP_DIR}/lfpFunctor.h)
+  set(FIVOX_USE_LFP ON)
+  add_definitions(-DFIVOX_USE_LFP)
+endif()
 
 add_subdirectory(fivox)
 add_subdirectory(apps)

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,12 @@ Changelog {#changelog}
 
 # git master {#master}
 
+* [#4](https://github.com/BlueBrain/Fivox/pull/4)
+  Add LFP functor from separate repo. Move all the voltage-specific logic to
+  the FieldFunctor, so CompartmentLoader can be used with other type of reports
+  (e.g. currents in LFP).
+  Add radius attribute in Event, used in the CompartmentLoader.
+  Adapt tests and default values to latest TestData (370ebee).
 * [7](https://github.com/BlueBrain/Fivox/pull/7):
   Add data decomposition in voxelize tool
 * [20437](https://bbpcode.epfl.ch/code/#/c/20437/)

--- a/fivox/CMakeLists.txt
+++ b/fivox/CMakeLists.txt
@@ -24,6 +24,10 @@ set(FIVOX_PUBLIC_HEADERS
   vsdLoader.h
 )
 
+if(FIVOX_USE_LFP)
+  list(APPEND FIVOX_PUBLIC_HEADERS lfp/lfpFunctor.h)
+endif()
+
 set(FIVOX_HEADERS
   beerLambertProjectionImageFilter.h
 )
@@ -40,8 +44,8 @@ set(FIVOX_SOURCES
 )
 
 set(FIVOX_LINK_LIBRARIES
-  PUBLIC ${ITK_LIBRARIES} Lunchbox vmmlib
-  PRIVATE ${Boost_LIBRARIES} Brion Brain Monsteer)
+  PUBLIC ${ITK_LIBRARIES} Brion Lunchbox vmmlib
+  PRIVATE ${Boost_LIBRARIES} Brain Monsteer)
 
 # Optionally enable rtree from boost_geometry, if found
 if(EXISTS "${Boost_INCLUDE_DIR}/boost/geometry.hpp")

--- a/fivox/compartmentLoader.cpp
+++ b/fivox/compartmentLoader.cpp
@@ -49,15 +49,12 @@ public:
         , _report( _config.getReportSource( params.getReport( )),
                    brion::MODE_READ, _target)
     {
-        _report.updateMapping( _target );
-
         brain::Circuit circuit( _config );
         const auto morphologies = circuit.loadMorphologies(
             _target, brain::Circuit::COORDINATES_GLOBAL );
 
         helpers::addCompartmentEvents( morphologies, _report, output );
     }
-
 
     ssize_t load( const float time )
     {
@@ -66,7 +63,7 @@ public:
             return -1;
 
         for( size_t i = 0; i != values->size( ); ++i )
-            _output.update( i, ( *values )[i] - brion::MINIMUM_VOLTAGE );
+            _output[i].value = ( *values )[i];
 
         return values->size();
     }

--- a/fivox/event.h
+++ b/fivox/event.h
@@ -26,16 +26,20 @@
 
 namespace fivox
 {
-/** A positional event with a value to be sampled. */
+/** A positional event with a value to be sampled and optionally a radius of
+ *  influence (0 by default)
+*/
 struct Event
 {
-  Event( const Vector3f& pos, const float val )
+  Event( const Vector3f& pos, const float val, const float rad = 0.f )
       : position( pos )
       , value( val )
+      , radius( rad )
   {}
 
-  Vector3f position;
+  const Vector3f position;
   float value;
+  float radius;
 };
 } // end namespace fivox
 

--- a/fivox/eventFunctor.h
+++ b/fivox/eventFunctor.h
@@ -65,7 +65,11 @@ protected:
             LBINFO << "Clamping sampled value " << value << " to 1"
                    << std::endl;
         }
-        return std::min( value, 1.0f ) * std::numeric_limits< TPixel >::max();
+        else if( value < 0.f )
+            LBINFO << "Clamping sampled value " << value << " to 0"
+                   << std::endl;
+        return std::min( std::max( value, 0.f ), 1.f ) *
+               std::numeric_limits< TPixel >::max();
     }
 
     EventSourcePtr _source;

--- a/fivox/eventSource.cpp
+++ b/fivox/eventSource.cpp
@@ -103,6 +103,12 @@ const Events& EventSource::getEvents() const
     return _impl->events;
 }
 
+Event& EventSource::operator[]( const size_t index )
+{
+    assert( index < _impl->events.size( ));
+    return _impl->events[index];
+}
+
 Events EventSource::findEvents( const AABBf& area LB_UNUSED ) const
 {
 #ifdef USE_BOOST_GEOMETRY
@@ -124,7 +130,7 @@ Events EventSource::findEvents( const AABBf& area LB_UNUSED ) const
         for( const Value& value : hits )
         {
             const Event& val = _impl->events[ value.second ];
-            if( val.value )
+            if( val.value != VALUE_UNSET )
                 events.push_back( val );
         }
         return events;
@@ -160,20 +166,6 @@ void EventSource::add( const Event& event )
 
     _impl->boundingBox.merge( event.position );
     _impl->events.push_back( event );
-}
-
-void EventSource::update( const size_t index, float value )
-{
-    assert( index < _impl->events.size( ));
-    static float clamped = 0.f;
-    value *= _impl->magnitude;
-    if( value < clamped )
-    {
-        clamped = value;
-        LBINFO << "Clamping event " << value << " to 0" << std::endl;
-    }
-
-    _impl->events[ index ].value = std::max( value, 0.f );
 }
 
 void EventSource::beforeGenerate()

--- a/fivox/eventSource.h
+++ b/fivox/eventSource.h
@@ -44,6 +44,14 @@ public:
     const Events& getEvents() const;
 
     /**
+     * Get a reference to an event contained in the EventSource by its index.
+     *
+     * @param index Index of the event that will be returned
+     * @return event stored in the EventSource with the specified index.
+     */
+    Event& operator[]( const size_t index );
+
+    /**
      * Find all events in the given area.
      *
      * Returns a conservative set of events, may contain events outside of the
@@ -62,9 +70,6 @@ public:
 
     /** Add a new event and update the bounding box. Not thread safe. */
     void add( const Event& event );
-
-    /** Update the value of an existing event. */
-    void update( const size_t index, const float value );
 
     /** @internal Called before data is read. Not thread safe.  */
     void beforeGenerate();

--- a/fivox/frequencyFunctor.h
+++ b/fivox/frequencyFunctor.h
@@ -37,11 +37,16 @@ class FrequencyFunctor : public EventFunctor< TImage >
     typedef typename Super::TSpacing TSpacing;
 
 public:
-    FrequencyFunctor() {}
+    FrequencyFunctor( const float magnitude )
+        : _magnitude( magnitude )
+    {}
     virtual ~FrequencyFunctor() {}
 
     TPixel operator()( const TPoint& point, const TSpacing& spacing )
         const override;
+
+private:
+    const float _magnitude;
 };
 
 template< class TImage > inline typename FrequencyFunctor< TImage >::TPixel
@@ -65,7 +70,7 @@ FrequencyFunctor< TImage >::operator()( const TPoint& itkPoint,
 
     float sum = 0.f;
     for( const Event& event : events )
-        sum = std::max( sum, event.value );
+        sum = std::max( sum, event.value * _magnitude );
     return Super::_scale( sum );
 }
 

--- a/fivox/helpers.h
+++ b/fivox/helpers.h
@@ -104,23 +104,30 @@ inline void addCompartmentEvents(
 
         if( sectionId == 0 )
         {
-            const auto event = Event( morphology.getSoma().getCentroid(), 0.f );
+            const auto& soma = morphology.getSoma();
+            const auto event = Event( soma.getCentroid(), VALUE_UNSET,
+                                      soma.getMeanRadius( ));
             for( size_t k = 0; k != compartments; ++k)
                 output.add( event );
             continue;
         }
 
-        const auto section = morphology.getSection(sectionId);
-
-        const float length = 1.f / float( compartments );
         brion::floats samples;
         samples.reserve( compartments );
-        for( float k = length * .5f; k < 1.0; k += length )
+        // normalized compartment length
+        const float normLength = 1.f / float( compartments );
+        for( float k = normLength * .5f; k < 1.0; k += normLength )
             samples.push_back( k );
 
-        const auto points = section.getSamples( samples );
+        const auto& neuronSection = morphology.getSection( sectionId );
+
+        // actual compartment length
+        const float compartmentLength = normLength * neuronSection.getLength();
+
+        const auto& points = neuronSection.getSamples( samples );
         for( const auto& point : points )
-            output.add( Event( point.get_sub_vector< 3 >(), 0.f ));
+            output.add( Event( point.get_sub_vector< 3 >(), VALUE_UNSET,
+                               compartmentLength * .2f ));
     }
 }
 

--- a/fivox/somaLoader.cpp
+++ b/fivox/somaLoader.cpp
@@ -50,7 +50,7 @@ public:
         brain::Vector3fs positions = circuit.getPositions( gids );
 
         for( size_t i = 0; i < gids.size(); ++i )
-            output.add( Event( positions[i], 0.f ));
+            output.add( Event( positions[i], VALUE_UNSET ));
     }
 
     ssize_t load( const float time )
@@ -66,8 +66,8 @@ public:
         for( size_t i = 0; i < gids.size(); ++i )
         {
             // This code assumes that section 0 is the soma.
-            const float v = voltages[offsets[i][0]] - brion::MINIMUM_VOLTAGE;
-            _output.update( i, v );
+            const float v = voltages[offsets[i][0]];
+            _output[i].value = v;
         }
         return gids.size();
     }

--- a/fivox/spikeLoader.cpp
+++ b/fivox/spikeLoader.cpp
@@ -71,7 +71,7 @@ public:
             const Vector3f position( lexical_cast< float >( matrix[i][0] ),
                                      lexical_cast< float >( matrix[i][1] ),
                                      lexical_cast< float >( matrix[i][2] ));
-            _output.add( Event( position, 0.f ));
+            _output.add( Event( position, VALUE_UNSET ));
             _gidIndex[gid] = i++;
         }
         _spikesPerNeuron.resize( gids.size( ));
@@ -144,7 +144,8 @@ public:
                                              : _loadSpikesSlow( start, end );
 
         for( size_t i = 0; i < _spikesPerNeuron.size(); ++i )
-            _output.update( i, _spikesPerNeuron[i] );
+            _output[i].value = _spikesPerNeuron[i] ? _spikesPerNeuron[i]
+                                                   : VALUE_UNSET;
 
         return numSpikes;
     }

--- a/fivox/types.h
+++ b/fivox/types.h
@@ -56,6 +56,7 @@ enum VolumeType
 {
     TYPE_UNKNOWN,      //!< Unknown URI scheme
     TYPE_COMPARTMENTS, //!< BBP compartment simulation reports
+    TYPE_LFP,          //!< BBP Local Field Potential computation
     TYPE_SOMAS,        //!< BBP soma simulation reports
     TYPE_SPIKES,       //!< BBP spike simulation reports
     TYPE_SYNAPSES,     //!< BBP synapse positions
@@ -67,6 +68,7 @@ enum FunctorType
 {
     FUNCTOR_UNKNOWN,
     FUNCTOR_DENSITY, //!< sum( magnitude of events in voxel ) / volume of voxel
+    FUNCTOR_LFP,     //!< LFP computation
     FUNCTOR_FIELD,   //!< quadratic falloff of magnitude in space
     FUNCTOR_FREQUENCY //!< maximum magnitude of all events in voxel
 };
@@ -79,6 +81,8 @@ enum SourceType
     SOURCE_FRAME //!< e.g. compartment reports
 };
 
+/** Used to mark a value as "unset" */
+const float VALUE_UNSET = std::numeric_limits< float >::max();
 }
 
 // ITK forward decls

--- a/fivox/vsdLoader.cpp
+++ b/fivox/vsdLoader.cpp
@@ -102,7 +102,7 @@ public:
         const float depth = yMax - event.position[1];
         const float eventValue =
             normVoltage * area * _curve.getAttenuation( depth );
-        _output.update( index, eventValue );
+        _output[index].value = eventValue;
     }
 };
 

--- a/tests/sources.cpp
+++ b/tests/sources.cpp
@@ -36,6 +36,9 @@
 #include <fivox/compartmentLoader.h>
 #include <fivox/eventFunctor.h>
 #include <fivox/imageSource.h>
+#ifdef FIVOX_USE_LFP
+#  include <fivox/lfp/lfpFunctor.h>
+#endif
 #include <fivox/somaLoader.h>
 #include <fivox/spikeLoader.h>
 #include <fivox/synapseLoader.h>
@@ -83,7 +86,7 @@ inline float _testKernel(
 
     // set up size and origin for loaded data
     fivox::EventSourcePtr source = filter->getFunctor()->getSource();
-    source->load( 95.f );
+    source->load( 5.f );
     const fivox::AABBf& bbox = source->getBoundingBox();
     const fivox::Vector3f& position = bbox.getMin();
     const float extent = bbox.getDimension().find_max();
@@ -204,37 +207,45 @@ struct SourcesFixture
 
 BOOST_FIXTURE_TEST_SUITE( sources, SourcesFixture )
 
-BOOST_AUTO_TEST_CASE( fivox_source )
+BOOST_AUTO_TEST_CASE( fivoxVoltages_source )
 {
-    // Compartement report 'allvoltage' (binary) contains timestamps
-    // between 0 and 1000 with a Dt=0.1 => data range is 0.0 to 100.0 ms
-    testSource( "fivox://", 4.513671875f, 0.0189120417f,
-                vmml::Vector2ui( 0, 1000 ));
+    // Compartment report 'voltages' (binary) contains timestamps
+    // between 0 and 100 with a Dt=0.1 => data range is 0.0 to 10.0 ms
+    testSource( "fivox://", 0.54296875f, 0.0022559839199516318f,
+                vmml::Vector2ui( 0, 100 ));
 }
+
+#ifdef FIVOX_USE_LFP
+BOOST_AUTO_TEST_CASE( fivoxLFP_source )
+{
+    // Compartment currents report 'currents' (binary) contains timestamps
+    // between 0 and 100 with a Dt=0.1 => data range is 0.0 to 10.0 ms
+    testSource( "fivoxlfp://", 0.f, 1.1370177737005287e-07f,
+                vmml::Vector2ui( 0, 100 ));
+}
+#endif
 
 BOOST_AUTO_TEST_CASE( fivoxSomas_source )
 {
-    // Soma report 'voltage' (binary) contains timestamps
-    // between 0 and 1000 with a Dt=0.1 => data range is 0.0 to 100.0 ms
-    testSource( "fivoxSomas://", 0.455078125f, 0.0030322455124291992f,
-                vmml::Vector2ui( 0, 1000 ));
+    // Soma report 'somas' (binary) contains timestamps
+    // between 0 and 100 with a Dt=0.1 => data range is 0.0 to 10.0 ms
+    testSource( "fivoxSomas://", 0.005859375f, 4.3455195964270388e-05f,
+                vmml::Vector2ui( 0, 100 ));
 }
 
 BOOST_AUTO_TEST_CASE( fivoxSpikes_source )
 {
-    // Spikes report timestamps range between 0.25 and 99.95 ms
+    // Spikes report timestamps range between 0.725 and 9.975 ms
     // Better, but not always available:
     // "fivoxSpikes:///gpfs/bbp.cscs.ch/home/nachbaur/BlueConfig_3m",
-    testSource( "fivoxSpikes://", 0.7421875f, 0.0029296876164153218f,
-                vmml::Vector2ui( 10, 3598 ));
+    testSource( "fivoxSpikes://?duration=1,dt=1",
+                2.490234375f, 0.0146484375f, vmml::Vector2ui( 0, 9 ));
 
 }
 
 BOOST_AUTO_TEST_CASE( fivoxSynapses_source )
 {
     // Synapse reports don't have time support and return a 1-frame interval
-    // Better, but not always available data:
-    // "fivoxSynapses:///gpfs/bbp.cscs.ch/home/nachbaur/BlueConfig_3m,target=L23_DBC",
     testSource( "fivoxSynapses://", 0.03515625f, 0.00017834029219887526f,
                 vmml::Vector2ui( 0, 1 ));
 }

--- a/tests/uriHandler.cpp
+++ b/tests/uriHandler.cpp
@@ -45,12 +45,11 @@ BOOST_AUTO_TEST_CASE(URIHandlerCompartments)
     BOOST_CHECK_EQUAL( handler.getType(), fivox::VolumeType::TYPE_COMPARTMENTS );
 #ifdef FIVOX_USE_BBPTESTDATA
     BOOST_CHECK_EQUAL( handler.getConfig(), BBP_TEST_BLUECONFIG );
-    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "Layer1" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "allvoltage" );
+    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "mini50" );
 #else
     BOOST_CHECK_EQUAL( handler.getTarget( "" ), "" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "voltage" );
 #endif
+    BOOST_CHECK_EQUAL( handler.getReport(), "voltages" );
     BOOST_CHECK_EQUAL( handler.getTarget( "foo" ), "foo" );
     BOOST_CHECK_EQUAL( handler.getDt(), -1.f );
     BOOST_CHECK_EQUAL( handler.getDuration(), 10.0f );
@@ -81,12 +80,11 @@ BOOST_AUTO_TEST_CASE(URIHandlerSoma)
     BOOST_CHECK_EQUAL( handler.getType(), fivox::VolumeType::TYPE_SOMAS );
 #ifdef FIVOX_USE_BBPTESTDATA
     BOOST_CHECK_EQUAL( handler.getConfig(), BBP_TEST_BLUECONFIG );
-    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "Layer1" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "voltage" );
+    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "mini50" );
 #else
     BOOST_CHECK_EQUAL( handler.getTarget( "" ), "" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "soma" );
 #endif
+    BOOST_CHECK_EQUAL( handler.getReport(), "somas" );
 }
 
 BOOST_AUTO_TEST_CASE(URIHandlerSpikes)
@@ -96,11 +94,10 @@ BOOST_AUTO_TEST_CASE(URIHandlerSpikes)
 #ifdef FIVOX_USE_BBPTESTDATA
     BOOST_CHECK_EQUAL( handler.getConfig(), BBP_TEST_BLUECONFIG );
     BOOST_CHECK_EQUAL( handler.getTarget( "" ), "Column" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "allvoltage" );
 #else
     BOOST_CHECK_EQUAL( handler.getTarget( "" ), "" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "voltage" );
 #endif
+    BOOST_CHECK_EQUAL( handler.getReport(), "voltages" );
 }
 
 BOOST_AUTO_TEST_CASE(URIHandlerSynapses)
@@ -109,12 +106,11 @@ BOOST_AUTO_TEST_CASE(URIHandlerSynapses)
     BOOST_CHECK_EQUAL( handler.getType(), fivox::VolumeType::TYPE_SYNAPSES );
 #ifdef FIVOX_USE_BBPTESTDATA
     BOOST_CHECK_EQUAL( handler.getConfig(), BBP_TEST_BLUECONFIG );
-    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "Column" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "allvoltage" );
+    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "mini50" );
 #else
     BOOST_CHECK_EQUAL( handler.getTarget( "" ), "" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "voltage" );
 #endif
+    BOOST_CHECK_EQUAL( handler.getReport(), "voltages" );
 }
 
 BOOST_AUTO_TEST_CASE(URIHandlerVSD)
@@ -126,10 +122,9 @@ BOOST_AUTO_TEST_CASE(URIHandlerVSD)
                        + "/../share/Fivox/configs/BlueConfigVSD" );
 #endif
 #ifdef FIVOX_USE_BBPTESTDATA
-    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "Layer1" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "voltage" );
+    BOOST_CHECK_EQUAL( handler.getTarget( "" ), "mini50" );
 #else
     BOOST_CHECK_EQUAL( handler.getTarget( "" ), "" );
-    BOOST_CHECK_EQUAL( handler.getReport(), "soma" );
 #endif
+    BOOST_CHECK_EQUAL( handler.getReport(), "voltages" );
 }


### PR DESCRIPTION
Move all the voltage-specific logic to the FieldFunctor,
so CompartmentLoader can be used with other type of reports
(e.g. currents in LFP).
Add radius attribute in Event, used in the CompartmentLoader.
