### PR TITLE
Add parameter to extend the volume size

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,9 @@ Changelog {#changelog}
 
 # git master {#master}
 
+* [#45](https://github.com/BlueBrain/Fivox/pull/45)
+  Add parameter to extend the volume size. The cutoff distance no longer grows
+  the resulting volume.
 * [#44](https://github.com/BlueBrain/Fivox/pull/44)
   Optimizations. Modify memory layout in EventSource so computations can be
   vectorized for performance.

--- a/fivox/livre/dataSource.cpp
+++ b/fivox/livre/dataSource.cpp
@@ -150,8 +150,8 @@ DataSource::DataSource( const livre::DataSourcePluginData& pluginData )
 
     const AABBf& bbox = loader->getBoundingBox();
     uint32_t depth = 0;
-    const Vector3f fullResolution =
-        ( bbox.getSize() + loader->getCutOffDistance() * 2.0f ) * resolution;
+    const Vector3f fullResolution = resolution *
+                  ( bbox.getSize() + _impl->params.getExtendDistance() * 2.0f );
     Vector3f blockResolution = fullResolution;
 
     // maxTextureSize value should be retrieved from OpenGL. But at this

--- a/fivox/uriHandler.cpp
+++ b/fivox/uriHandler.cpp
@@ -55,6 +55,7 @@ const float _dt = -1.0f; // loaders use experiment/report dt
 const size_t _maxBlockSize = LB_64MB;
 const float _resolution = 10.0f; // voxels per unit
 const float _cutoff = 100.0f; // micrometers
+const float _extend = 0.f; // micrometers
 
 EventSourcePtr _newLoader( const URIHandler& data )
 {
@@ -215,7 +216,10 @@ public:
         { return _get( "maxBlockSize", _maxBlockSize ); }
 
     float getCutoffDistance() const
-        { return std::max( _get( "cutoff", _cutoff ), 0.0f );}
+        { return std::max( _get( "cutoff", _cutoff ), 0.f );}
+
+    float getExtendDistance() const
+        { return std::max( _get( "extend", _extend ), 0.f );}
 
     bool showProgress() const;
 
@@ -385,6 +389,11 @@ size_t URIHandler::getMaxBlockSize() const
 float URIHandler::getCutoffDistance() const
 {
     return _impl->getCutoffDistance();
+}
+
+float URIHandler::getExtendDistance() const
+{
+    return _impl->getExtendDistance();
 }
 
 VolumeType URIHandler::getType() const

--- a/fivox/uriHandler.h
+++ b/fivox/uriHandler.h
@@ -135,6 +135,16 @@ public:
     float getCutoffDistance() const;
 
     /**
+     * Get the additional distance, in micrometers, by which the original data
+     * volume will be extended. By default, the volume extension matches the
+     * bounding box of the data events.
+     *
+     * @return the distance to extend the data volume, in micrometers.
+     *         If invalid or empty, return 0.
+     */
+    float getExtendDistance() const;
+
+    /**
      * Get the type of the volume that is being loaded (present in the URI
      * schema)
      * @return the type of the volume


### PR DESCRIPTION
Modify the volume extent independently from the cutoff distance,
using by default the bounding box of the data events (extend=0)