### PR TITLE
Refactor the voxelize tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ make
 
 The voxelize command line tool supports the following parameters:
 
-@snippet apps/voxelize/voxelize.cpp Parameters
+@snippet apps/voxelize/voxelize.cpp VoxelizeParameters
+
+in addition to the ones that are common to all command line applications:
+
+@snippet apps/commandLineApplication.h AppParameters
 
 # About
 

--- a/apps/commandLineApplication.h
+++ b/apps/commandLineApplication.h
@@ -1,0 +1,235 @@
+
+/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+ *                          Jafet.VillafrancaDiaz@epfl.ch
+ *                          Stefan.Eilemann@epfl.ch
+ *                          Daniel.Nachbaur@epfl.ch
+ *
+ * This file is part of Fivox <https://github.com/BlueBrain/Fivox>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of Eyescale Software GmbH nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fivox/types.h>
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+
+namespace vmml
+{
+std::istream& operator>>( std::istream& is, Vector2f& vec )
+{
+    return is >> std::skipws >> vec.x() >> vec.y();
+}
+
+std::istream& operator>>( std::istream& is, Vector2ui& vec )
+{
+    return is >> std::skipws >> vec.x() >> vec.y();
+}
+}
+
+namespace
+{
+typedef fivox::FloatVolume::Pointer VolumePtr;
+typedef fivox::ImageSource< fivox::FloatVolume > ImageSource;
+typedef ImageSource::Pointer ImageSourcePtr;
+
+/**
+ * Abstract class that behaves as a wrapper for the boost::program_options
+ * evaluation, containing the common options for all Fivox applications:
+ * volume URI and frame range options (time/times and frame/frames).
+ *
+ * Other applications can inherit from this class to extend the number of
+ * options and functionality.
+ */
+class CommandLineApplication
+{
+public:
+    CommandLineApplication()
+        : _options( "Supported options", 140 /*line len*/ )
+        , _uri( "fivox://" )
+    {
+        _options.add_options()
+//! [AppParameters] @anchor CommandLineApplication
+            ( "help,h", "Show help message" )
+            ( "version,v", "Show program name and version" )
+            ( "volume", po::value< std::string >(),
+//! [VolumeParameters] @anchor VolumeParameters
+              "Volume URI with parameters in the form:\n"
+              "- Compartment reports:\n"
+              "    fivox[compartments]://BlueConfig?report=string&target=string\n"
+              "- Soma reports:\n"
+              "    fivoxsomas://BlueConfig?report=string&target=string\n"
+              "- Spike reports:\n"
+              "    fivoxspikes://BlueConfig?duration=float&spikes=path&target=string\n"
+              "- Synapse densities:\n"
+              "    fivoxsynapses://BlueConfig?target=string\n"
+              "- Voltage-sensitive dye reports:\n"
+              "    fivoxvsd://BlueConfig?dyecurve=string&target=string\n"
+              "\n"
+              "Parameters for all types :\n"
+              "- BlueConfig: BlueConfig file path\n"
+              "              (default: BBPTestData)\n"
+              "- target: name of the BlueConfig target (default: CircuitTarget)\n"
+              "- inputMin/inputMax: minimum and maximum input values to be considered for rescaling\n"
+              "                     (defaults: [0.0, 2.0] for Spikes and Synapses\n"
+              "                                [-190.0, 0.0] for Compartments with TestData, [-80.0, 0.0] otherwise\n"
+              "                                [-15.0, 0.0] for Somas with TestData, [-80.0, 0.0] otherwise\n"
+              "                                [-0.0000147, 0.00225] for LFP with TestData, [-10.0, 10.0] otherwise\n"
+              "                                [-100000.0, 300.0] for VSD)\n"
+              "- functor: type of functor to sample the data into the voxels\n"
+              "             (defaults: \"density\" for Synapses,\n"
+              "                        \"frequency\" for Spikes,\n"
+              "                        \"field\" for Compartments, Somas and VSD)\n"
+              "- resolution: number of voxels per micrometer (default: 10.0)\n"
+              "- maxBlockSize: maximum memory usage allowed for one block in bytes\n"
+              "                (default: 64MB)\n"
+              "- cutoff: the cutoff distance in micrometers (default: 100).\n"
+              "- extend: the additional distance, in micrometers, by which the\n"
+              "          original data volume will be extended in every dimension\n"
+              "          (default: 0, the volume extent matches the bounding box\n"
+              "          of the data events). Changing this parameter will result\n"
+              "          in more volumetric data, and therefore more computation\n"
+              "          time\n"
+              "- showProgress: display progress bar for current voxelization step\n"
+              "                (default: 0/off)\n"
+              "\n"
+              "Parameters for Compartments:\n"
+              "- report: name of the compartment report\n"
+              "          (default: 'voltage'; 'allvoltage' if BlueConfig is BBPTestData)\n"
+              "- dt: timestep between requested frames in milliseconds\n"
+              "      (default: report dt)\n"
+              "\n"
+              "Parameters for Somas:\n"
+              "- report: name of the soma report\n"
+              "          (default: 'soma'; 'voltage' if BlueConfig is BBPTestData)\n"
+              "- dt: timestep between requested frames in milliseconds\n"
+              "      (default: report dt)\n"
+              "\n"
+              "Parameters for Spikes:\n"
+              "- duration: time window in milliseconds to load spikes (default: 10)\n"
+              "- spikes: path to an alternate out.dat/out.spikes file\n"
+              "          (default: SpikesPath specified in the BlueConfig)\n"
+              "\n"
+              "Parameters for VSD:\n"
+              "- report: name of the soma report\n"
+              "          (default: 'soma'; 'voltage' if BlueConfig is BBPTestData)\n"
+              "- dyecurve: path to the dye curve file to apply, e.g. attenuation\n"
+              "            (default: no file; attenuation of 1.0)\n"
+//! [VolumeParameters]
+              )
+            ( "time,t", po::value< float >(),
+              "Timestamp to load in the report" )
+            ( "times", po::value< fivox::Vector2f >(),
+              "Time range [start end) to load in the report" )
+            ( "frame,f", po::value< unsigned >(),
+              "Frame to load in the report" )
+            ( "frames", po::value< fivox::Vector2ui >(),
+              "Frame range [start end) to load in the report" );
+//! [AppParameters]
+    }
+
+    virtual ~CommandLineApplication() {}
+
+    /**
+     * Parse the command line options, taking as parameters the count and list
+     * of arguments (input for boost::program_options::parse_command_line)
+     *
+     * @return a flow control bool, returning false when the evaluation of the
+     * options is not needed anymore (e.g. when using --help or --version), true
+     * otherwise
+     */
+    virtual bool parse( int argc, char* argv[] )
+    {
+        po::store( po::parse_command_line( argc, argv, _options ), _vm );
+        po::notify( _vm );
+
+        if( _vm.count( "help" ))
+        {
+            std::cout << _options << std::endl;
+            return false;
+        }
+
+        if( _vm.count( "version" ))
+        {
+            std::cout << argv[0] << " version " << fivox::Version::getString()
+                      << std::endl;
+            return false;
+        }
+
+        if( _vm.count( "volume" ))
+            _uri = _vm["volume"].as< std::string >();
+        else
+            LBINFO << "Using " << _uri << " as volume" << std::endl;
+
+        return true;
+    }
+
+    /**
+     * Return the frame range after evaluating the command line options,
+     * considering also a dt parameter for the 'time' and 'times' options.
+     *
+     * @param dt the length of each frame, in microseconds. Needed to compute
+     * the frame range when specifying only the 'time' or 'times' options
+     * @return a vector of two components representing the frame range
+     */
+    fivox::Vector2ui getFrameRange( const float dt ) const
+    {
+        if( _vm.count( "time" ))
+        {
+            const size_t frame = _vm["time"].as< float >() / dt;
+            return fivox::Vector2ui( frame, frame + 1 );
+        }
+        if( _vm.count( "times" ))
+        {
+            const fivox::Vector2f times = _vm["times"].as< fivox::Vector2f >();
+            return fivox::Vector2ui( times.x() / dt, times.y() / dt );
+        }
+        if( _vm.count( "frame" ))
+        {
+            const size_t frame = _vm["frame"].as< unsigned >();
+            return fivox::Vector2ui( frame, frame + 1 );
+        }
+        if( _vm.count( "frames" ))
+            return _vm["frames"].as< fivox::Vector2ui >();
+
+        return fivox::Vector2ui( 0, 1 ); // just frame 0 by default
+    }
+
+    /**
+     * Return the volume URI as a string
+     * @return a std::string containing the volume URI
+     */
+    const std::string& getFivoxParams() const
+    {
+        return _uri;
+    }
+
+protected:
+    po::options_description _options;
+    po::variables_map _vm;
+    std::string _uri;
+};
+
+}

--- a/apps/voxelize/CMakeLists.txt
+++ b/apps/voxelize/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(VOXELIZE_HEADERS
   beerLambertProjectionImageFilter.h
+  ../commandLineApplication.h
   scaleFilter.h
   volumeHandler.h
   volumeWriter.h

--- a/apps/voxelize/voxelize.cpp
+++ b/apps/voxelize/voxelize.cpp
@@ -33,19 +33,16 @@
 
 #include "volumeHandler.h"
 #include "volumeWriter.h"
+#include "../commandLineApplication.h"
 
 #include <fivox/fivox.h>
 
 #include <lunchbox/file.h>
 #include <lunchbox/log.h>
 #include <lunchbox/uri.h>
-#include <boost/program_options.hpp>
 
 namespace
 {
-typedef fivox::FloatVolume::Pointer VolumePtr;
-typedef fivox::ImageSource< fivox::FloatVolume > ImageSource;
-typedef ImageSource::Pointer ImageSourcePtr;
 
 template< typename T >
 void _sample( ImageSourcePtr source, const vmml::Vector2ui& frameRange,
@@ -84,235 +81,123 @@ void _sample( ImageSourcePtr source, const vmml::Vector2ui& frameRange,
 }
 }
 
-namespace vmml
+class Voxelize : public CommandLineApplication
 {
-std::istream& operator>>( std::istream& is, Vector2f& vec )
-{
-    return is >> std::skipws >> vec.x() >> vec.y();
-}
+public:
+    Voxelize()
+        : _outputFile( "volume" )
+        , _decompose( 0, 1 )
+    {
+        _options.add_options()
+//! [VoxelizeParameters] @anchor Voxelize
+            ( "datatype,d", po::value< std::string >()->default_value( "float" ),
+              "Type of the data in the output volume "
+              "[float (default), int, short, char]" )
+            ( "size,s", po::value< size_t >(),
+              "Size of the output volume. If specified, this parameter will "
+              "overwrite the resolution setting in the uri." )
+            ( "output,o", po::value< std::string >(),
+              "Name of the output volume file (mhd and raw); contains frame number "
+              "if --frames or --times" )
+            ( "projection,p", po::value< double >(), "Generate the corresponding "
+              "projected 2D image (only for VSD volumes), using the specified "
+              "value as the absorption + scattering coefficient (units per "
+              "micrometer) in the Beer-Lambert law. Must be a positive value." )
+            ( "decompose", po::value< fivox::Vector2ui >(),
+              "'rank size' data-decomposition for parallel job submission" );
+//! [VoxelizeParameters]
+    }
 
-std::istream& operator>>( std::istream& is, Vector2ui& vec )
-{
-    return is >> std::skipws >> vec.x() >> vec.y();
-}
-}
+    bool parse( int argc, char* argv[] ) final
+    {
+        if( !CommandLineApplication::parse( argc, argv ))
+            return false;
 
-namespace po = boost::program_options;
+        if( _vm.count( "output" ))
+            _outputFile = _vm["output"].as< std::string >();
+
+        if( _vm.count( "decompose" ))
+        {
+            _decompose = _vm["decompose"].as< fivox::Vector2ui >();
+
+            const size_t numDigits = std::to_string( _decompose[1] ).length();
+            std::ostringstream os;
+            os << "_" << std::setfill('0') << std::setw( numDigits )
+               << _decompose[0] << "_" << _decompose[1];
+            _outputFile += os.str();
+        }
+        return true;
+    }
+
+    void sample()
+    {
+        const ::fivox::URIHandler params( getFivoxParams( ));
+        ImageSourcePtr source = params.newImageSource< float >();
+        ::fivox::EventSourcePtr loader = source->getFunctor()->getSource();
+        const fivox::AABBf& bbox = loader->getBoundingBox();
+
+        const fivox::Vector3f& extent( bbox.getSize() +
+                                       params.getExtendDistance() * 2.f );
+
+        size_t size;
+        if( _vm.count( "size" ))
+            size = _vm["size"].as< size_t >();
+        else
+        {
+            const fivox::Vector3f& sizeVoxels = extent * params.getResolution();
+            size = (size_t)std::ceil( sizeVoxels.find_max( ));
+        }
+
+        VolumeHandler volumeHandler( size, extent );
+
+        VolumePtr output = source->GetOutput();
+        output->SetRegions( volumeHandler.computeRegion( _decompose ));
+        output->SetSpacing( volumeHandler.computeSpacing( ));
+        output->SetOrigin( volumeHandler.computeOrigin( bbox.getCenter( )));
+
+        const fivox::Vector2ui frameRange( getFrameRange( loader->getDt( )));
+
+        const double sigmaVSDProjection =
+            params.getType() == fivox::TYPE_VSD && _vm.count( "projection" ) ?
+                                _vm["projection"].as< double >() : -1.0;
+
+        const std::string& datatype( _vm["datatype"].as< std::string >( ));
+        if( datatype == "char" )
+        {
+            LBINFO << "Sampling volume as char (uint8_t) data" << std::endl;
+            _sample< uint8_t >( source, frameRange, sigmaVSDProjection,
+                                params, _outputFile );
+        }
+        else if( datatype == "short" )
+        {
+            LBINFO << "Sampling volume as short (uint16_t) data" << std::endl;
+            _sample< uint16_t >( source, frameRange, sigmaVSDProjection,
+                                 params, _outputFile );
+        }
+        else if( datatype == "int" )
+        {
+            LBINFO << "Sampling volume as int (uint32_t) data" << std::endl;
+            _sample< uint32_t >( source, frameRange, sigmaVSDProjection,
+                                 params, _outputFile );
+        }
+        else
+        {
+            LBINFO << "Sampling volume as floating point data" << std::endl;
+            _sample< float >( source, frameRange, sigmaVSDProjection,
+                              params, _outputFile );
+        }
+    }
+
+private:
+    std::string _outputFile;
+    ::fivox::Vector2ui _decompose;
+};
 
 int main( int argc, char* argv[] )
 {
-    // Default values
-    std::string outputFile( "volume" );
-    std::string uri( "fivox://" );
-
-    // Argument parsing
-    po::variables_map vm;
-    po::options_description desc( "Supported options", 140 /*line len*/ );
-    desc.add_options()
-//! [Parameters] @anchor parameters
-        ( "help,h", "Show help message" )
-        ( "version,v", "Show program name and version" )
-        ( "volume", po::value< std::string >(),
-//! [Usage] @anchor voxelize
-          "Volume URI with parameters in the form:\n"
-          "- Compartment reports:\n"
-          "    fivox[compartments]://BlueConfig?report=string&target=string[ or #target]\n"
-          "- Soma reports:\n"
-          "    fivoxsomas://BlueConfig?report=string&target=string[ or #target]\n"
-          "- Spike reports:\n"
-          "    fivoxspikes://BlueConfig?duration=float&spikes=path&target=string[ or #target]\n"
-          "- Synapse densities:\n"
-          "    fivoxsynapses://BlueConfig?target=string[ or #target]\n"
-          "- Voltage-sensitive dye reports:\n"
-          "    fivoxvsd://BlueConfig?dyecurve=string&target=string[ or #target]\n"
-          "\n"
-          "Note: If target=string and #target parameters are given at the same time\n"
-          "target=string has the precedence over #target parameter. Giving the #target as\n"
-          "a parameter is deprecated\n"
-          "\n"
-          "Parameters for all types :\n"
-          "- BlueConfig: BlueConfig file path\n"
-          "              (default: BBPTestData)\n"
-          "- target: name of the BlueConfig target (default: CircuitTarget)\n"
-          "- inputMin/inputMax: minimum and maximum input values to be considered for rescaling\n"
-          "                     (defaults: [0.0, 2.0] for Spikes and Synapses\n"
-          "                                [-190.0, 0.0] for Compartments with TestData, [-80.0, 0.0] otherwise\n"
-          "                                [-15.0, 0.0] for Somas with TestData, [-80.0, 0.0] otherwise\n"
-          "                                [-0.0000147, 0.00225] for LFP with TestData, [-10.0, 10.0] otherwise\n"
-          "                                [-100000.0, 300.0] for VSD)\n"
-          "- functor: type of functor to sample the data into the voxels\n"
-          "             (defaults: \"density\" for Synapses,\n"
-          "                        \"frequency\" for Spikes,\n"
-          "                        \"field\" for Compartments, Somas and VSD)\n"
-          "- resolution: number of voxels per micrometer (default: 10.0)\n"
-          "- maxBlockSize: maximum memory usage allowed for one block in bytes\n"
-          "                (default: 64MB)\n"
-          "- cutoff: the cutoff distance in micrometers (default: 100).\n"
-          "- extend: the additional distance, in micrometers, by which the\n"
-          "          original data volume will be extended in every dimension\n"
-          "          (default: 0, the volume extent matches the bounding box\n"
-          "          of the data events). Changing this parameter will result\n"
-          "          in more volumetric data, and therefore more computation\n"
-          "          time\n"
-          "- showProgress: display progress bar for current voxelization step\n"
-          "                (default: 0/off)\n"
-          "\n"
-          "Parameters for Compartments:\n"
-          "- report: name of the compartment report\n"
-          "          (default: 'voltage'; 'allvoltage' if BlueConfig is BBPTestData)\n"
-          "- dt: timestep between requested frames in milliseconds\n"
-          "      (default: report dt)\n"
-          "\n"
-          "Parameters for Somas:\n"
-          "- report: name of the soma report\n"
-          "          (default: 'soma'; 'voltage' if BlueConfig is BBPTestData)\n"
-          "- dt: timestep between requested frames in milliseconds\n"
-          "      (default: report dt)\n"
-          "\n"
-          "Parameters for Spikes:\n"
-          "- duration: time window in milliseconds to load spikes (default: 10)\n"
-          "- spikes: path to an alternate out.dat/out.spikes file\n"
-          "          (default: SpikesPath specified in the BlueConfig)\n"
-          "\n"
-          "Parameters for VSD:\n"
-          "- report: name of the soma report\n"
-          "          (default: 'soma'; 'voltage' if BlueConfig is BBPTestData)\n"
-          "- dyecurve: path to the dye curve file to apply, e.g. attenuation\n"
-          "            (default: no file; attenuation of 1.0)\n"
-//! [Usage]
-          )
-        ( "datatype,d", po::value< std::string >()->default_value( "float" ),
-          "Type of the data in the output volume "
-          "[float (default), int, short, char]" )
-        ( "size,s", po::value< size_t >(),
-          "Size of the output volume. If specified, this parameter will "
-          "overwrite the resolution setting in the uri." )
-        ( "time,t", po::value< float >(),
-          "Timestamp to load in the report" )
-        ( "times", po::value< fivox::Vector2f >(),
-          "Time range [start end) to load in the report" )
-        ( "frame,f", po::value< unsigned >(),
-          "Frame to load in the report" )
-        ( "frames", po::value< fivox::Vector2ui >(),
-          "Frame range [start end) to load in the report" )
-        ( "output,o", po::value< std::string >()->default_value( outputFile ),
-          "Name of the output volume file (mhd and raw); contains frame number "
-          "if --frames or --times" )
-        ( "projection,p", po::value< double >(), "Generate the corresponding "
-          "projected 2D image (only for VSD volumes), using the specified "
-          "value as the absorption + scattering coefficient (units per "
-          "micrometer) in the Beer-Lambert law. Must be a positive value." )
-        ( "decompose", po::value< fivox::Vector2ui >(),
-          "'rank size' data-decomposition for parallel job submission" );
-//! [Parameters]
-
-    po::store( po::parse_command_line( argc, argv, desc ), vm );
-    po::notify( vm );
-
-    if( vm.count( "help" ))
-    {
-        std::cout << desc << std::endl;
+    Voxelize app;
+    if( !app.parse( argc, argv ))
         return EXIT_SUCCESS;
-    }
 
-    if( vm.count( "version" ))
-    {
-        std::cout << argv[0] << " version " << fivox::Version::getString()
-                  << std::endl;
-        return EXIT_SUCCESS;
-    }
-
-    if( vm.count( "volume" ))
-        uri = vm["volume"].as< std::string >();
-    else
-        LBINFO << "Using " << uri << " as volume" << std::endl;
-
-    if( vm.count( "output" ))
-        outputFile = vm["output"].as< std::string >();
-
-    fivox::Vector2ui decompose( 0, 1 );
-    if( vm.count( "decompose" ))
-    {
-        decompose = vm["decompose"].as< fivox::Vector2ui >();
-
-        const size_t numDigits = std::to_string( decompose[1] ).length();
-        std::ostringstream os;
-        os << "_" << std::setfill('0') << std::setw( numDigits )
-           << decompose[0] << "_" << decompose[1];
-        outputFile += os.str();
-    }
-
-    ::fivox::URIHandler params( uri );
-    ImageSourcePtr source = params.newImageSource< float >();
-    ::fivox::EventSourcePtr loader = source->getFunctor()->getSource();
-    const fivox::AABBf& bbox = loader->getBoundingBox();
-
-    const fivox::Vector3f& extent( bbox.getSize() +
-                                   params.getExtendDistance() * 2.f );
-
-    size_t size;
-    if( vm.count( "size" ))
-        size = vm["size"].as< size_t >();
-    else
-    {
-        const fivox::Vector3f& sizeInVoxels = extent * params.getResolution();
-        size = (size_t)std::ceil( sizeInVoxels.find_max( ));
-    }
-
-    VolumeHandler volumeHandler( size, extent );
-
-    VolumePtr output = source->GetOutput();
-    output->SetRegions( volumeHandler.computeRegion( decompose ));
-    output->SetSpacing( volumeHandler.computeSpacing( ));
-    output->SetOrigin( volumeHandler.computeOrigin( bbox.getCenter( )));
-
-    fivox::Vector2ui frameRange( 0, 1 ); // just frame 0 by default
-    if( vm.count( "time" ))
-    {
-        const size_t frame = vm["time"].as< float >() / loader->getDt();
-        frameRange = fivox::Vector2ui( frame, frame + 1 );
-    }
-    if( vm.count( "times" ))
-    {
-        const fivox::Vector2f times = vm["times"].as< fivox::Vector2f >();
-        frameRange = fivox::Vector2ui( times.x() / loader->getDt(),
-                                       times.y() / loader->getDt( ));
-    }
-    if( vm.count( "frame" ))
-    {
-        const size_t frame = vm["frame"].as< unsigned >();
-        frameRange = fivox::Vector2ui( frame, frame + 1 );
-    }
-    if( vm.count( "frames" ))
-        frameRange = vm["frames"].as< fivox::Vector2ui >();
-
-    const double sigmaVSDProjection =
-            params.getType() == fivox::TYPE_VSD && vm.count( "projection" ) ?
-                vm["projection"].as< double >() : -1.0;
-
-    const std::string& datatype( vm["datatype"].as< std::string >( ));
-    if( datatype == "char" )
-    {
-        LBINFO << "Sampling volume as char (uint8_t) data" << std::endl;
-        _sample< uint8_t >( source, frameRange, sigmaVSDProjection,
-                            params, outputFile );
-    }
-    else if( datatype == "short" )
-    {
-        LBINFO << "Sampling volume as short (uint16_t) data" << std::endl;
-        _sample< uint16_t >( source, frameRange, sigmaVSDProjection,
-                             params, outputFile );
-    }
-    else if( datatype == "int" )
-    {
-        LBINFO << "Sampling volume as int (uint32_t) data" << std::endl;
-        _sample< uint32_t >( source, frameRange, sigmaVSDProjection,
-                             params, outputFile );
-    }
-    else
-    {
-        LBINFO << "Sampling volume as floating point data" << std::endl;
-        _sample< float >( source, frameRange, sigmaVSDProjection,
-                          params, outputFile );
-    }
+    app.sample();
 }

--- a/fivox/uriHandler.cpp
+++ b/fivox/uriHandler.cpp
@@ -115,8 +115,7 @@ public:
         config.reset( new brion::BlueConfig( uri.getPath( )));
 #endif
 
-        const std::string& target = _get( "target" ).empty() ? uri.getFragment() :
-                                             _get( "target" );
+        const std::string& target = _get( "target" );
         if( target == "*" )
         {
             const brain::Circuit circuit( *config );

--- a/fivox/uriHandler.h
+++ b/fivox/uriHandler.h
@@ -33,7 +33,7 @@ namespace fivox
  * Process an URI to provide all the parameters specified in it.
  *
  * The following parameters are parsed:
- * @snippet apps/voxelize/voxelize.cpp Usage
+ * @snippet apps/commandLineApplication.h VolumeParameters
  */
 class URIHandler
 {

--- a/tests/uriHandler.cpp
+++ b/tests/uriHandler.cpp
@@ -75,11 +75,11 @@ BOOST_AUTO_TEST_CASE(compartment_parameters)
 BOOST_AUTO_TEST_CASE(compartment_targets)
 {
     const fivox::URIHandler handler1(
-        "fivoxcompartment://?target=mini50#Layer1" );
+        "fivoxcompartment://?target=mini50" );
     BOOST_CHECK_EQUAL( handler1.getGIDs().size(), 50 );
 
     const fivox::URIHandler handler2(
-        "fivoxcompartment://?report=simulation#Layer1" );
+        "fivoxcompartment://?target=Layer1&report=simulation" );
     BOOST_CHECK_EQUAL( handler2.getGIDs().size(), 20 );
     BOOST_CHECK_EQUAL( handler2.getReport(), "simulation" );
 }


### PR DESCRIPTION
Extract the parts that may be common for other tools
and create an abstract class CommandLineApplication that
is used as a base for all the applications.

Remove support of deprecated #target in the volume URI.