### PR TITLE
Fix the volume writing when there are dots in the output path

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # git master {#master}
 
+* [#63](https://github.com/BlueBrain/Fivox/pull/63)
+  Fix the volume writing when there are dots in the output path
 * [#61](https://github.com/BlueBrain/Fivox/pull/61)
   Use the timestamp in the output file names (only in compute-vsd)
 * [#59](https://github.com/BlueBrain/Fivox/pull/59)


### PR DESCRIPTION
When a "." was present in the specified --output path, the voxelize
app was failing to find the extension, leading to unexpected behaviors.
Now only the file name is considered to search for the extension.
Also, now it's possible to write also series of volumes using a different
format than the default (.mhd).