### PR TITLE
Add export-point-sprites option in compute-vsd

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git d288194
+# CMake/common https://github.com/Eyescale/CMake.git 11ee9c1

--- a/CMake/GitExternal.cmake
+++ b/CMake/GitExternal.cmake
@@ -281,13 +281,10 @@ if(EXISTS ${GIT_EXTERNALS} AND NOT GIT_EXTERNAL_SCRIPT_MODE)
           if(NOT TARGET update)
             add_custom_target(update)
           endif()
-          if(NOT TARGET update-gitexternal)
-            add_custom_target(update-gitexternal)
-            add_custom_target(flatten-gitexternal)
-            add_dependencies(update update-gitexternal)
-          endif()
-          if(NOT TARGET ${PROJECT_NAME}-flatten-gitexternal)
+          if(NOT TARGET ${PROJECT_NAME}-update-gitexternal)
+            add_custom_target(${PROJECT_NAME}-update-gitexternal)
             add_custom_target(${PROJECT_NAME}-flatten-gitexternal)
+            add_dependencies(update ${PROJECT_NAME}-update-gitexternal)
           endif()
 
           # Create a unique, flat name
@@ -328,7 +325,7 @@ endif()")
             COMMENT "Update ${REPO} in ${GIT_EXTERNALS_BASE}"
             DEPENDS ${GIT_EXTERNAL_TARGET}
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-          add_dependencies(update-gitexternal
+          add_dependencies(${PROJECT_NAME}-update-gitexternal
             update-gitexternal-${GIT_EXTERNAL_NAME})
 
           # Flattens a git external repository into its parent repo:
@@ -346,12 +343,10 @@ endif()")
             COMMENT "Flatten ${REPO} into ${DIR}"
             DEPENDS ${PROJECT_NAME}-make-branch
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${DIR}")
-          add_dependencies(flatten-gitexternal
-            flatten-gitexternal-${GIT_EXTERNAL_NAME})
           add_dependencies(${PROJECT_NAME}-flatten-gitexternal
             flatten-gitexternal-${GIT_EXTERNAL_NAME})
 
-          foreach(_target flatten-gitexternal-${GIT_EXTERNAL_NAME} ${PROJECT_NAME}-flatten-gitexternal flatten-gitexternal update-gitexternal-${GIT_EXTERNAL_NAME} ${GIT_EXTERNAL_TARGET} update-gitexternal update)
+          foreach(_target flatten-gitexternal-${GIT_EXTERNAL_NAME} ${PROJECT_NAME}-flatten-gitexternal update-gitexternal-${GIT_EXTERNAL_NAME} ${GIT_EXTERNAL_TARGET} ${PROJECT_NAME}-update-gitexternal update)
             set_target_properties(${_target} PROPERTIES
               EXCLUDE_FROM_DEFAULT_BUILD ON FOLDER git)
           endforeach()

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # git master {#master}
 
+* [#69](https://github.com/BlueBrain/Fivox/pull/69)
+  Add option in compute-vsd tool to export the VSD events as point sprite files
 * [#65](https://github.com/BlueBrain/Fivox/pull/65)
   Add option in compute-vsd tool to export the soma positions as a text file
 * [#64](https://github.com/BlueBrain/Fivox/pull/64)

--- a/doc/userGuide/computeVSD.md
+++ b/doc/userGuide/computeVSD.md
@@ -12,7 +12,7 @@ as a new loader (VSDLoader).
 
     compute-vsd --volume 'fivoxvsd://BlueConfig?report=voltages&target=Column&areas=/path/to/report/area.bbp&dt=0.1'
                 --curve /path/to/dyecurve.txt --depth 2000 [--interpolate-attenuation]
-                --v0 -65 --g0 10000 [--ap-threshold -55] [--export-volume]
+                --v0 -65 --g0 10000 [--ap-threshold -55] [--export-volume] [--export-point-sprites]
                 --sigma 0.001 --sensor-res 512 --sensor-dim 1000
                 --frame[s] '0 10' (or alternatively, --time[s] '0 100') --output /path/to/output/prefix_
 
@@ -40,6 +40,8 @@ values from the dye curve file. Use nearest-neighbor otherwise (default).
 * --ap-threshold: Action potential threshold in millivolts
 * --export-volume: If specified, generate a 3D volume containing the VSD signal
 (.mhd and .raw files)
+* --export-point-sprites: If specified, generate a set of files describing the
+VSD events as point sprites (.psh, .psp and .psi files)
 
 ##### Beer-Lambert projection
 
@@ -130,6 +132,10 @@ the corresponding region.
 applied to the VSD value s the result of lineraly interpolating the two closest
 values in the input dye curve file, so the curve is smoother.
 
+If the _export-point-sprites_ command line option is specified, the resulting
+information (VSD events) will be written to disk in the form of point sprite
+files.
+
 
 ### Voxelization
 
@@ -194,6 +200,12 @@ Example, attenuating more in the middle part:
 0.83
 0.95
 ```
+
+#### VSD point sprite files:
+
+A metadata header ASCII file (.psh), a binary file containing the positions for
+all the VSD events (.psp), and one binary file containing all the event values
+for each generated frame (.psi).
 
 #### Output 3D volume:
 

--- a/fivox/vsdLoader.cpp
+++ b/fivox/vsdLoader.cpp
@@ -31,7 +31,6 @@
 #include <brain/neuron/section.h>
 #include <brain/neuron/soma.h>
 
-#include <fstream>
 #include <cassert>
 
 namespace fivox


### PR DESCRIPTION
If specified, produce a set of point sprite files
with the information about the VSD events