### PR TITLE
Add GenericLoader to load events from file.

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git 3d5d284
+# CMake/common https://github.com/Eyescale/CMake.git d86f669

--- a/apps/computeVSD/computeVSD.cpp
+++ b/apps/computeVSD/computeVSD.cpp
@@ -328,7 +328,11 @@ private:
 
             file << "VSDPositionFile=" << _outputFile + ".psp" << std::endl;
             file << "VSDIntensityFile=" << filename + ".psi" << std::endl;
-            file << "TimeStep=" << _eventSource->getDt() << std::endl;
+
+            // Should be called TimeStamp but need to remain TimeStep because of
+            // compatibility issues.
+            file << "TimeStep=" << _eventSource->getCurrentTime() << std::endl;
+
             if( file.good( ))
                 LBINFO << "Point Sprite header written as " << pshFile
                        << std::endl;

--- a/apps/voxelize/voxelize.cpp
+++ b/apps/voxelize/voxelize.cpp
@@ -110,7 +110,9 @@ public:
               "Name of the output volume file (mhd and raw); contains frame "
               "number if --frames or --times" )
             ( "decompose", po::value< fivox::Vector2ui >(),
-              "'rank size' data-decomposition for parallel job submission" );
+              "'rank size' data-decomposition for parallel job submission" )
+            ( "export-events", po::value< std::string >(),
+              "Name of the output events file (binary format)" );
 //! [VoxelizeParameters]
     }
 
@@ -159,6 +161,10 @@ public:
 
         ::fivox::EventSourcePtr loader = source->getEventSource();
         const fivox::Vector2ui frameRange( getFrameRange( loader->getDt( )));
+
+        if( _vm.count( "export-events" ))
+            loader->write( _vm["export-events"].as< std::string >(),
+                           fivox::EventFileFormat::binary );
 
         const std::string& datatype( _vm["datatype"].as< std::string >( ));
         if( datatype == "char" )

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,9 @@ Changelog {#changelog}
 
 # git master {#master}
 
+* [#81](https://github.com/BlueBrain/Fivox/pull/81)
+  Replace TestLoader by GenericLoader, adding the possibility to load events
+  from file
 * [#77](https://github.com/BlueBrain/Fivox/pull/77),
   [#78](https://github.com/BlueBrain/Fivox/pull/78)
   Enable CUDA implementation of the lfp computation.

--- a/doc/feature/genericEventLoading.md
+++ b/doc/feature/genericEventLoading.md
@@ -1,0 +1,131 @@
+Generic event loading {#genericEventLoading}
+=====================
+
+For research and debugging purposes, sometimes we need to quickly visualize
+a set of events in 3D space. For example, in a neural circuit with synaptic
+connectivity, we are interested in visualizing the position of the post-synaptic
+cells; or for validation purposes, we want to check that the LFP computation is
+done correctly for a predefined set of events.
+
+Since the variety of use cases is so wide, each of them with its own
+particularities, we need to find a generic way of loading any predefined set of
+events.
+
+The solution chosen for this feature is the loading of events from file. This
+offers users flexibility to generate all types of events in a simple and generic
+way, so the tool doesn't need to be adapted to fit the particular needs of any
+situation.
+
+A generic event is always defined by its 3D position, radius and value,
+regardless of the use case. It could be the cases that the radius and value are
+not relevant, but they are always present (e.g. in the synaptic connectivity,
+the radius can be 0, and value 1, as we will count each event as one cell).
+
+
+## Requirements
+
+* Users should be able to specify their own input events, as easily as possible,
+from an external source (i.e. file).
+* The format of the input file should be clearly defined and documented.
+* All the library common capabilities should still be available for their use
+with this feature. For example, generating 3D volumes with different
+resolutions and using any available functor.
+
+
+## API
+
+A TestLoader is already present in Fivox, which generates a set of 7 events in a
+fixed position, and is used for basic use cases such as the validation of the
+LFP computation in a test case. The input URI in this case is as follows:
+
+    "fivoxtest://?resolution=1&functor=lfp"
+
+What we need for the loading of any number of generic events is very similar to
+this, but we need a way to specify the source of our events, instead of
+generating them at runtime. We can use the BlueConfig path location as the event
+file path. A change in the name might also be convenient, as it is not anymore
+just for testing purposes. The loader and schema names are open for discussion.
+
+    "fivox:///absolute/path/to/events/file?resolution=1&functor=lfp"
+
+The path to the input file is optional, behaving like the original TestLoader
+and creating the initial 7 events if it is omitted. Please note that, when using
+the GenericLoader, the events file path replaces the BlueConfig path (used
+in most of the scientific use cases).
+
+For simplicity, and for now, only the GenericLoader can read events from file.
+But any EventSource can write this type of files, dumping their contents (all
+the events and their corrresponding values that it contains at the moment).
+For that, a new method will be implemented in the base class:
+
+    bool EventSource::write( const std::string& filename, bool binary = true );
+
+The corresponding option should also be added in the _voxelize_ application,
+so users have access to it.
+
+
+## File format
+
+For the input file containing the events, two different formats should be
+supported, binary for performance, and ASCII for readability, but keeping the
+same layout.
+
+#### ASCII
+
+Header containing the version numbers and the format used, followed by all the
+events (one event per line).
+
+Example:
+
+```cpp
+# Fivox events (3D position, radius and value), in the following format:
+#     posX posY posZ radius value
+# File version: 1
+# Fivox version: 0.6.0
+Number of events: 10
+50.115 1971 61.384 1.0 1
+54.818 1997.1 71.462 1.0 2
+50.896 1760.8 56.659 1.0 3
+38.099 1807.9 30.819 1.0 4
+19.888 1755.2 69.948 1.0 5
+42.529 1730.5 50.998 1.0 6
+59.509 1742.3 50.691 1.0 7
+43.298 1826.1 57.443 1.0 8
+52.034 1595.8 55.536 1.0 9
+29.455 1451.9 28.081 1.0 10
+```
+
+#### Binary
+
+Two 32-bit values at the beginning (magic and version numbers), followed by
+all the events, with five 32-bit floating point values
+(posX posY posZ radius value) per event.
+
+
+## Issues
+
+### 1: What names should we use for the loader and URI schema?
+
+Resolved: Use GenericLoader and "fivox://".
+
+We can replace the TestLoader by GenericLoader. Other alternatives are:
+EventLoader, GenericEventLoader, FileLoader.
+
+As for the URI schema, we have "fivoxtest://", that could be replaced by
+simply "fivox://" (which is now used for the CompartmentLoader, but that could
+be changed), "fivoxfile://", "fivoxevents://", "fivoxgeneric://".
+
+### 2: Why not extending this feature for any loader, to be able to store the event positions in a cache file after their initial creation?
+
+Resolved: Yes. We can write the events from any loader, but read only from
+the GenericLoader (for now).
+
+It's an interesting possibility, specially considering the amount of time it
+takes in some occasions to just create the events based on a BlueConfig file and
+target, for example. The problem is that not every loader works the same way
+(for example the SynapseLoader loads by chunks, not everything at once at
+construction time), and this addition would also complicate the implementation
+and usage of each of the loaders. For the events reading, we should keep this
+feature self-contained in the new GenericLoader, at least for now, and then we
+see if it is possible to extend it for any use case. For writing, there should
+not be any problem in making it available for any loader.

--- a/fivox/CMakeLists.txt
+++ b/fivox/CMakeLists.txt
@@ -13,6 +13,7 @@ set(FIVOX_PUBLIC_HEADERS
   eventSource.h
   fieldFunctor.h
   frequencyFunctor.h
+  genericLoader.h
   imageSource.h
   imageSource.hxx
   progressObserver.h
@@ -20,7 +21,6 @@ set(FIVOX_PUBLIC_HEADERS
   somaLoader.h
   spikeLoader.h
   synapseLoader.h
-  testLoader.h
   types.h
   uriHandler.h
   volumeHandler.h
@@ -37,11 +37,11 @@ endif()
 set(FIVOX_SOURCES
   compartmentLoader.cpp
   eventSource.cpp
+  genericLoader.cpp
   progressObserver.cpp
   somaLoader.cpp
   spikeLoader.cpp
   synapseLoader.cpp
-  testLoader.cpp
   uriHandler.cpp
   volumeHandler.cpp
   vsdLoader.cpp

--- a/fivox/eventSource.h
+++ b/fivox/eventSource.h
@@ -187,6 +187,36 @@ public:
     /** @return the maximum number of chunks provided by the data source. */
     FIVOX_API size_t getNumChunks() const;
 
+    /**
+     * Read events from the specified file. It will first try to read it as a
+     * binary file, checking the expected magic number; if not found, it will
+     * read it as an ASCII, in the expected format (see specification).
+     *
+     * The contents of the file will be used to set the events in the
+     * EventSource.
+     *
+     * @param filename path of the file to read the events from.
+     * @return true if the events were read correctly, false otherwise.
+     * @throw std::runtime_error if the specified file is empty.
+     * @throw std::runtime_error if the binary file version is incompatible.
+     * @throw std::runtime_error if the number of events to load from an ASCII
+     * file is 0, or not specified.
+     * @throw std::runtime_error if any of the events being read is ill-formed.
+     */
+    FIVOX_API bool read( const std::string& filename );
+
+    /**
+     * Write events to the specified file. It is possible to specify the format
+     * of the output (binary or ASCII, see specification for reference).
+     *
+     * @param filename path of the file to write the events to.
+     * @param format file format in which the event file will be written
+     * (EventFileFormat::ascii and EventFileFormat::binary are supported).
+     * @return true if the file was succesfully written, false otherwise.
+     */
+    FIVOX_API bool write( const std::string& filename,
+                          EventFileFormat format ) const;
+
 protected:
     explicit EventSource( const URIHandler& params );
 

--- a/fivox/genericLoader.cpp
+++ b/fivox/genericLoader.cpp
@@ -20,7 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "testLoader.h"
+#include "genericLoader.h"
 #include "uriHandler.h"
 
 #include <lunchbox/log.h>
@@ -32,19 +32,27 @@
 namespace fivox
 {
 
-class TestLoader::Impl
+class GenericLoader::Impl
 {
 public:
-    explicit Impl( EventSource& output )
+    explicit Impl( EventSource& output, const URIHandler& params )
         : _output( output )
+        , _file( params.getConfigPath( ))
     {
-        _output.resize( 7 );
+        if( _file.empty( ))
+        {
+            _output.resize( 7 );
 
-        for( uint8_t y = 0; y < 5; ++y )
-            _output.update( y, Vector3f( 0.f, y * 10.f, 0.f ), 1.f );
+            for( uint8_t y = 0; y < 5; ++y )
+                _output.update( y, Vector3f( 0.f, y * 10.f, 0.f ), 1.f );
 
-        _output.update( 5, Vector3f( 3.f, 5.f, 4.f ), 1.f );
-        _output.update( 6, Vector3f( 5.f, 2.f, 1.f ), 1.f );
+            _output.update( 5, Vector3f( 3.f, 5.f, 4.f ), 1.f );
+            _output.update( 6, Vector3f( 5.f, 2.f, 1.f ), 1.f );
+
+            return;
+        }
+
+        _output.read( _file );
     }
 
     ssize_t load()
@@ -57,26 +65,27 @@ public:
     }
 
     EventSource& _output;
+    const std::string& _file;
 };
 
-TestLoader::TestLoader( const URIHandler& params )
+GenericLoader::GenericLoader( const URIHandler& params )
     : EventSource( params )
-    , _impl( new TestLoader::Impl( *this ))
+    , _impl( new GenericLoader::Impl( *this, params ))
 {
     if( getDt() < 0.f )
         setDt( 1.f );
 }
 
-TestLoader::~TestLoader()
+GenericLoader::~GenericLoader()
 {}
 
-Vector2f TestLoader::_getTimeRange() const
+Vector2f GenericLoader::_getTimeRange() const
 {
     return Vector2f( 0.f, 100.f );
 }
 
-ssize_t TestLoader::_load( const size_t /*chunkIndex*/,
-                           const size_t /*numChunks*/ )
+ssize_t GenericLoader::_load( const size_t /*chunkIndex*/,
+                              const size_t /*numChunks*/ )
 {
     return _impl->load();
 }

--- a/fivox/genericLoader.h
+++ b/fivox/genericLoader.h
@@ -17,8 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef FIVOX_TESTLOADER_H
-#define FIVOX_TESTLOADER_H
+#ifndef FIVOX_GENERICLOADER_H
+#define FIVOX_GENERICLOADER_H
 
 #include <fivox/api.h>
 #include <fivox/eventSource.h> // base class
@@ -26,20 +26,20 @@
 namespace fivox
 {
 /**
- * Create a set of dummy events, arranged in a vertical straight line,
- * to be sampled by an EventFunctor.
+ * Load a set of events from file, if specified. Otherwise, generate a set of
+ * dummy events arranged in a vertical straight line.
  */
-class TestLoader : public EventSource
+class GenericLoader : public EventSource
 {
 public:
     /**
-    * Construct a new test event source.
+    * Construct a new generic event source.
     *
     * @param params the URIHandler object containing the parameters
     * to define the event source
     */
-    FIVOX_API explicit TestLoader( const URIHandler& params );
-    FIVOX_API virtual ~TestLoader();
+    FIVOX_API explicit GenericLoader( const URIHandler& params );
+    FIVOX_API virtual ~GenericLoader();
 
 private:
     /** @name Abstract interface implementation */

--- a/fivox/types.h
+++ b/fivox/types.h
@@ -80,8 +80,9 @@ using EventFunctorPtr = std::shared_ptr< EventFunctor< TImage >>;
 enum class VolumeType
 {
     unknown,      //!< Unknown URI scheme
-    test,         /*!< Test type that creates fixed events
-                            (e.g. for validation of different functors */
+    generic,      /*!< Generic type that loads events from file (if present),
+                       or creates fixed events (e.g. for validation of different
+                       functors) */
     compartments, //!< BBP compartment simulation reports
     somas,        //!< BBP soma simulation reports
     spikes,       //!< BBP spike simulation reports
@@ -105,6 +106,13 @@ enum class SourceType
 {
     event, //!< e.g. spikes reports
     frame  //!< e.g. compartment reports
+};
+
+/** Supported formats to read or write event files */
+enum class EventFileFormat
+{
+    ascii,
+    binary
 };
 
 /** Indicates to consider all data for potential rescaling. */

--- a/fivox/uriHandler.cpp
+++ b/fivox/uriHandler.cpp
@@ -33,10 +33,10 @@
 #endif
 #include <fivox/eventValueSummationImageSource.h>
 #include <fivox/functorImageSource.h>
+#include <fivox/genericLoader.h>
 #include <fivox/somaLoader.h>
 #include <fivox/spikeLoader.h>
 #include <fivox/synapseLoader.h>
-#include <fivox/testLoader.h>
 #include <fivox/vsdLoader.h>
 #ifdef FIVOX_USE_BBPTESTDATA
 #  include <BBP/TestDatasets.h>
@@ -69,11 +69,11 @@ public:
         : uri( parameters )
         , useTestData( false )
     {
-        if( getType() == VolumeType::test )
+        if( getType() == VolumeType::generic )
             return;
 
 #ifdef FIVOX_USE_BBPTESTDATA
-        useTestData = uri.getPath().empty( );
+        useTestData = uri.getPath().empty();
         config.reset( new brion::BlueConfig( useTestData ? BBP_TEST_BLUECONFIG3
                                                          : uri.getPath( )));
 #else
@@ -110,6 +110,11 @@ public:
         if( gids.empty( ))
             LBTHROW( std::runtime_error(
                      "No GIDs found for requested target '" + target + "'" ));
+    }
+
+    const std::string& getConfigPath() const
+    {
+        return uri.getPath();
     }
 
     const brion::BlueConfig& getConfig() const
@@ -245,6 +250,9 @@ public:
         std::stringstream desc;
         switch( getType( ))
         {
+        case VolumeType::generic:
+            desc << "generic events from " << getConfigPath() << "'";
+            break;
         case VolumeType::compartments:
         case VolumeType::somas:
             if( getFunctorType() == FunctorType::lfp )
@@ -277,7 +285,6 @@ public:
             desc << "VSD (Voltage-Sensitive Dye) from " << getReport()
                  << " for target '"  << _get( "target" ) << "'";
             break;
-        case VolumeType::test:
         default:
             return "";
         }
@@ -288,6 +295,10 @@ public:
     VolumeType getType() const
     {
         const std::string& scheme = uri.getScheme();
+        if( scheme == "fivox" )
+            return VolumeType::generic;
+        if( scheme == "fivoxcompartments" )
+            return VolumeType::compartments;
         if( scheme == "fivoxsomas" )
             return VolumeType::somas;
         if( scheme == "fivoxspikes" )
@@ -296,10 +307,6 @@ public:
             return VolumeType::synapses;
         if( scheme == "fivoxvsd" )
             return VolumeType::vsd;
-        if( scheme == "fivox" || scheme == "fivoxcompartments" )
-            return VolumeType::compartments;
-        if( scheme == "fivoxtest" )
-            return VolumeType::test;
 
         LBERROR << "Unknown URI scheme: " << scheme << std::endl;
         return VolumeType::unknown;
@@ -310,25 +317,20 @@ public:
         const std::string& functor = _get( "functor" );
         if( functor == "density" )
             return FunctorType::density;
-        if( functor == "lfp" )
-            return FunctorType::lfp;
         if( functor == "field" )
             return FunctorType::field;
         if( functor == "frequency" )
             return FunctorType::frequency;
+        if( functor == "lfp" )
+            return FunctorType::lfp;
 
         switch( getType( ))
         {
-        case VolumeType::spikes:
-        case VolumeType::synapses:
-            LBTHROW( std::runtime_error(
-                         "No functor support for synapses and spikes. "));
         case VolumeType::compartments:
         case VolumeType::somas:
-        case VolumeType::vsd:
-        case VolumeType::test:
-        default:
             return FunctorType::field;
+        default:
+            return FunctorType::unknown;
         }
     }
 
@@ -393,6 +395,11 @@ URIHandler::URIHandler( const URI& params )
 
 URIHandler::~URIHandler()
 {}
+
+const std::string& URIHandler::getConfigPath() const
+{
+    return _impl->getConfigPath();
+}
 
 const brion::BlueConfig& URIHandler::getConfig() const
 {
@@ -488,7 +495,8 @@ std::string URIHandler::getHelp()
 {
     return
 //! [VolumeParameters] @anchor VolumeParameters
-        R"(- Compartment reports: fivox[compartments]://BlueConfig?report=string&target=string
+        R"(- Generic events from file: fivox://EventsFile
+- Compartment reports: fivoxcompartments://BlueConfig?report=string&target=string
 - Soma reports: fivoxsomas://BlueConfig?report=string&target=string
 - Spike reports: fivoxspikes://BlueConfig?duration=float&spikes=path&target=string
 - Synapse densities: fivoxsynapses://BlueConfig?target=string
@@ -496,7 +504,7 @@ std::string URIHandler::getHelp()
 - Voltage-sensitive dye reports: fivoxvsd://BlueConfig?report=string&target=string
 
 Parameters for all types :
-- BlueConfig: BlueConfig file path (default: BBPTestData)
+- BlueConfig: BlueConfig absolute file path (default: BBPTestData)
 - target: name of the BlueConfig target (default: CircuitTarget)
 - preTarget: target for presynaptic neurons for synapse densities (default: unset)
 - postTarget: target for postsynaptic neurons for synapse densities (default: unset)
@@ -541,11 +549,9 @@ ImageSourcePtr< TImage > URIHandler::newImageSource() const
     EventSourcePtr eventSource = newEventSource();
 
     ImageSourcePtr< TImage > source;
-    switch( getType( ))
+    switch( getFunctorType( ))
     {
-    case VolumeType::spikes:
-    case VolumeType::synapses:
-    case VolumeType::vsd:
+    case FunctorType::unknown:
         source = EventValueSummationImageSource< TImage >::New();
         break;
     default:
@@ -568,8 +574,6 @@ ImageSourcePtr< TImage > URIHandler::newImageSource() const
         if( !cudaCapable )
 #endif
         {
-            LBINFO << "No CUDA-capable device is detected. "
-                   << "Using CPU implementation." << std::endl;
             auto functorSource = FunctorImageSource< TImage >::New();
             auto functor = newFunctor< TImage >();
             functorSource->setFunctor( functor );
@@ -592,14 +596,14 @@ EventSourcePtr URIHandler::newEventSource() const
     {
     case VolumeType::compartments:
         return std::make_shared< CompartmentLoader >( *this );
+    case VolumeType::generic:
+        return std::make_shared< GenericLoader >( *this );
     case VolumeType::somas:
         return std::make_shared< SomaLoader >( *this );
     case VolumeType::spikes:
         return std::make_shared< SpikeLoader >( *this );
     case VolumeType::synapses:
         return std::make_shared< SynapseLoader >( *this );
-    case VolumeType::test:
-        return std::make_shared< TestLoader >( *this );
     case VolumeType::vsd:
         return std::make_shared< VSDLoader >( *this );
     default:

--- a/fivox/uriHandler.h
+++ b/fivox/uriHandler.h
@@ -49,6 +49,13 @@ public:
     FIVOX_API virtual ~URIHandler(); //!< Destruct this parameter processor
 
     /**
+     * @return a string corresponding to the URI path specified in the
+     *         parameters (i.e. the Config raw path). Return an empty string if
+     *         not specified.
+     */
+    FIVOX_API const std::string& getConfigPath() const;
+
+    /**
      * @return the BlueConfig object from the parameters. For empty parameters,
      *         it returns the TestData's BlueConfig if available.
      */
@@ -162,14 +169,14 @@ public:
     FIVOX_API VolumeType getType() const;
 
     /**
-     * Available functors are "density", "field" and "frequency". If "functor"
-     * is unspecified, the default functor for the VolumeType is returned:
-     * - FUNCTOR_DENSITY for SYNAPSES
-     * - FUNCTOR_FREQUENCY for SPIKES
-     * - FUNCTOR_FIELD for COMPARTMENTS, SOMAS and VSD
+     * Available functors are "density", "field", "frequency" and "lfp".
+     * If "functor" is unspecified, the default functor for the VolumeType is
+     * returned:
+     * - FunctorType::field for VolumeType::compartments and VolumeType::somas
+     * - FunctorType::unknown otherwise
      *
      * @return the type of the functor to use, use VolumeType default functor
-     *          if unspecified.
+     *         if unspecified.
      */
     FIVOX_API FunctorType getFunctorType() const;
 

--- a/fivox/vsdLoader.cpp
+++ b/fivox/vsdLoader.cpp
@@ -77,7 +77,7 @@ public:
         for( size_t i = 0; i != voltages->size(); ++i )
         {
             const float voltage = ( *voltages )[i];
-            _updateEventValue( i, _spikeFilter ? std::min(voltage, _apThreshold)
+            _updateEventValue( i, _spikeFilter ? std::min(voltage, _apThreshold )
                                                : voltage, ( *_areas )[i] );
         }
         return voltages->size();

--- a/tests/lfpValidation.cpp
+++ b/tests/lfpValidation.cpp
@@ -53,7 +53,7 @@ const float expectedValue2 = 2.81135f;
 BOOST_AUTO_TEST_CASE( LfpValidation )
 {
     const fivox::URIHandler params( fivox::URI(
-               "fivoxtest://?resolution=1&cutoff=100&functor=lfp&extend=100" ));
+                   "fivox://?resolution=1&cutoff=100&functor=lfp&extend=100" ));
     auto volumeSource = params.newImageSource< fivox::FloatVolume >();
 
     typedef fivox::FloatVolume Image;

--- a/tests/sources.cpp
+++ b/tests/sources.cpp
@@ -32,11 +32,14 @@
 
 #define BOOST_TEST_MODULE Sources
 
+#include <boost/filesystem.hpp>
+
 #include "test.h"
 #include <fivox/compartmentLoader.h>
 #include <fivox/eventFunctor.h>
 #include <fivox/helpers.h>
 #include <fivox/imageSource.h>
+#include <fivox/genericLoader.h>
 #ifdef FIVOX_USE_LFP
 #  include <fivox/lfp/lfpFunctor.h>
 #endif
@@ -65,6 +68,46 @@ namespace
 
 const std::string _monsteerPluginScheme( "monsteer" );
 const size_t _minResolution = 8;
+
+void testGenericEvents( fivox::EventSourcePtr eventsource )
+{
+    boost::filesystem::path tempFile = boost::filesystem::unique_path();
+    std::string asciiFile = boost::filesystem::temp_directory_path().string()
+                            + "/" + tempFile.string() + ".ascii";
+    std::string binaryFile = boost::filesystem::temp_directory_path().string()
+                             + "/" + tempFile.string() + ".binary";
+
+    BOOST_CHECK( eventsource->write( asciiFile,
+                                     fivox::EventFileFormat::ascii ));
+    BOOST_CHECK( eventsource->write( binaryFile,
+                                     fivox::EventFileFormat::binary ));
+
+    fivox::URIHandler asciiSourceURI( servus::URI( "fivox://" + asciiFile ));
+    fivox::GenericLoader asciiSource( asciiSourceURI );
+
+    fivox::URIHandler binarySourceURI( servus::URI( "fivox://" + binaryFile ));
+    fivox::GenericLoader binarySource( binarySourceURI );
+
+    BOOST_CHECK_EQUAL( eventsource->getNumEvents( ),
+                       asciiSource.getNumEvents( ));
+    BOOST_CHECK_EQUAL( eventsource->getNumEvents( ),
+                       binarySource.getNumEvents( ));
+
+    for( uint32_t i = 0; i < asciiSource.getNumEvents( ); ++i )
+    {
+        BOOST_CHECK_CLOSE( asciiSource.getValues()[i],
+                           eventsource->getValues()[i], 0.001f );
+    }
+
+    for( uint32_t i = 0; i < binarySource.getNumEvents( ); ++i )
+    {
+        BOOST_CHECK_CLOSE( binarySource.getValues()[i],
+                           eventsource->getValues()[i], 0.001f );
+    }
+
+    boost::filesystem::remove( asciiFile );
+    boost::filesystem::remove( binaryFile );
+}
 
 template< typename Image >
 inline float _testKernel(
@@ -191,6 +234,7 @@ struct SourcesFixture
                       << ',' << std::setw(15)
                       << size*size*size / 1024.f / 1024.f / t2 << std::endl;
         }
+        testGenericEvents( filter1->getEventSource( ));
     }
 };
 }
@@ -201,15 +245,15 @@ BOOST_AUTO_TEST_CASE( fivoxVoltages_source )
 {
     // Compartment report 'voltages' (binary) contains timestamps
     // between 0 and 100 with a Dt=0.1 => data range is 0.0 to 10.0 ms
-    testSource( fivox::URI( "fivox://" ), 5.455078125f, -0.062685228640475543,
-                vmml::Vector2ui( 0, 100 ));
+    testSource( fivox::URI( "fivoxcompartments://" ), 5.455078125f,
+                -0.062685228640475543, vmml::Vector2ui( 0, 100 ));
 }
 
 BOOST_AUTO_TEST_CASE( fivoxSomas_source )
 {
     // Soma report 'somas' (binary) contains timestamps
     // between 0 and 100 with a Dt=0.1 => data range is 0.0 to 10.0 ms
-    testSource( fivox::URI( "fivoxSomas://" ), 0.f,
+    testSource( fivox::URI( "fivoxsomas://" ), 0.f,
                 -0.0016181814135052264, vmml::Vector2ui( 0, 100 ));
 }
 
@@ -218,7 +262,7 @@ BOOST_AUTO_TEST_CASE( fivoxLFP_source )
 {
     // Compartment currents report 'currents' (binary) contains timestamps
     // between 0 and 100 with a Dt=0.1 => data range is 0.0 to 10.0 ms
-    testSource( fivox::URI( "fivox://?functor=lfp" ), 0.f,
+    testSource( fivox::URI( "fivoxcompartments://?functor=lfp" ), 0.f,
                 3.3634767649011466e-09f, vmml::Vector2ui( 0, 100 ));
 }
 #endif
@@ -226,20 +270,20 @@ BOOST_AUTO_TEST_CASE( fivoxLFP_source )
 BOOST_AUTO_TEST_CASE( fivoxSpikes_source )
 {
     // Spikes report timestamps range between 0.725 and 9.975 ms
-    testSource( fivox::URI( "fivoxSpikes://?duration=1&dt=1&target=Column" ),
+    testSource( fivox::URI( "fivoxspikes://?duration=1&dt=1&target=Column" ),
                 0.005859375f, 0.005859375f, vmml::Vector2ui( 0, 9 ));
 }
 
 BOOST_AUTO_TEST_CASE( fivoxSynapses_source )
 {
     // Synapse reports don't have time support and return a 1-frame interval
-    testSource( fivox::URI( "fivoxSynapses://?target=Column" ), 7.42578125f,
+    testSource( fivox::URI( "fivoxsynapses://?target=Column" ), 7.42578125f,
                 437.92578125f, vmml::Vector2ui( 0, 1 ));
 }
 
 BOOST_AUTO_TEST_CASE( fivoxVSD_source )
 {
-    testSource( fivox::URI( "fivoxVSD://?target=allmini50" ),
+    testSource( fivox::URI( "fivoxvsd://?target=allmini50" ),
                 12.703125, -85293.598821282387f, vmml::Vector2ui( 0, 100 ));
 }
 

--- a/tests/uriHandler.cpp
+++ b/tests/uriHandler.cpp
@@ -48,7 +48,7 @@ inline std::ostream& operator << ( std::ostream& os, const VolumeType& type )
 
 BOOST_AUTO_TEST_CASE(compartment_defaults)
 {
-    const fivox::URIHandler handler( fivox::URI( "fivox://" ));
+    const fivox::URIHandler handler( fivox::URI( "fivoxcompartments://" ));
     BOOST_CHECK_EQUAL( handler.getType(), fivox::VolumeType::compartments );
     BOOST_CHECK_EQUAL( handler.getConfig().getCircuitSource(),
                  brion::BlueConfig( BBP_TEST_BLUECONFIG3 ).getCircuitSource( ));
@@ -61,21 +61,23 @@ BOOST_AUTO_TEST_CASE(compartment_defaults)
 
 BOOST_AUTO_TEST_CASE(compartment_full_circuit)
 {
-    const fivox::URIHandler handler( fivox::URI( "fivox://?target=*" ));
+    const fivox::URIHandler handler(
+                fivox::URI( "fivoxcompartments://?target=*" ));
     BOOST_CHECK_EQUAL( handler.getGIDs().size(), 1000 );
 }
 
 BOOST_AUTO_TEST_CASE(compartment_empty_target)
 {
     BOOST_CHECK_THROW(
-                fivox::URIHandler handler( fivox::URI( "fivox://?target=EmptyTarget" )),
-                std::runtime_error );
+        fivox::URIHandler handler(
+                       fivox::URI( "fivoxcompartments://?target=EmptyTarget" )),
+        std::runtime_error );
 }
 
 BOOST_AUTO_TEST_CASE(compartment_parameters)
 {
-    const fivox::URIHandler handler(
-        fivox::URI( "fivoxcompartment://?report=simulation&dt=0.2&target=Column" ));
+    const fivox::URIHandler handler( fivox::URI(
+               "fivoxcompartments://?report=simulation&dt=0.2&target=Column" ));
     BOOST_CHECK_EQUAL( handler.getGIDs().size(), 1000 );
     BOOST_CHECK_EQUAL( handler.getReport(), "simulation" );
     BOOST_CHECK_EQUAL( handler.getDt(), 0.2f );
@@ -84,11 +86,11 @@ BOOST_AUTO_TEST_CASE(compartment_parameters)
 BOOST_AUTO_TEST_CASE(compartment_targets)
 {
     const fivox::URIHandler handler1(
-        fivox::URI( "fivoxcompartment://?target=mini50" ));
+        fivox::URI( "fivoxcompartments://?target=mini50" ));
     BOOST_CHECK_EQUAL( handler1.getGIDs().size(), 50 );
 
     const fivox::URIHandler handler2(
-        fivox::URI( "fivoxcompartment://?target=Layer1&report=simulation" ));
+        fivox::URI( "fivoxcompartments://?target=Layer1&report=simulation" ));
     BOOST_CHECK_EQUAL( handler2.getGIDs().size(), 20 );
     BOOST_CHECK_EQUAL( handler2.getReport(), "simulation" );
 }


### PR DESCRIPTION
Added read and write methods in the EventSource, to
save/load events to/from binary or ASCII files.

Use "fivox://" for the GenericLoader ("fivoxcompartments://"
for the CompartmentLoader)

Replace TestLoader with new GenericLoader, behaving the same way
as previously when no events file is specified.