### PR TITLE
Fixed beer lambert accumulator in VSD computation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,13 @@ before_install:
   - brew update
   - brew outdated cmake || brew upgrade cmake
   - brew install cppcheck doxygen ninja
-  - brew install zeromq qt5 homebrew/science/hdf5 homebrew/science/insighttoolkit homebrew/science/vtk
+# We need to install gcc before hdf5 because otherwise hdf5 will fail.
+  # The or statement is a hack to ensure we override the existing gcc without
+  # having an error
+  - brew install gcc || brew link --overwrite gcc
+  - brew install cppcheck doxygen  hdf5 qt5  ninja vtk zeromq
+  - brew tap brewsci/homebrew-science
+  - brew install brewsci/science/insighttoolkit
   - pip install pyparsing
   - ssh-keyscan bbpcode.epfl.ch >> ~/.ssh/known_hosts
 script:

--- a/apps/computeVSD/computeVSD.cpp
+++ b/apps/computeVSD/computeVSD.cpp
@@ -125,6 +125,9 @@ public:
         projection->SetInput(input);
         projection->SetProjectionDimension(1); // projection along Y-axis
         projection->SetPixelSize(input->GetSpacing().GetElement(0));
+        projection->SetyOrigin(input->GetOrigin()[1]);
+        projection->SetCircuitHeight(_vm["depth"].as<float>());
+
         const double sigma = _vm["sigma"].as<double>();
         projection->SetSigma(sigma);
 

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # master
 
+* [#94](https://github.com/BlueBrain/Fivox/pull/94)
+  Fix depth calculation for exponential decay in VSD computation.
 * [#93](https://github.com/BlueBrain/Fivox/pull/93)
   Fix computeVSD scaling bug
 


### PR DESCRIPTION
There were two problems:
- The code was assuming that the accumulation proceeded from top to bottom
  in circuit space, but it was doing it from bottom to top (from 0 to n in
  image space). That translated in all depth values used for the exponential
  decay being wrong.
- Even if that was correct, the depth of a voxel was computed from the
  top of the bounding box of the somas, which is inconsistent when the
  attenuation curve which measures depth from a user given circuit height.

The tests don't need changing because they compare an average that masks
this problem. Proper tests should operate on simpler volumes where the
results can be manually computed